### PR TITLE
Refactor templating and `find' statements

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,26 @@
 document.getElementById('issueInputForm').addEventListener('submit', saveIssue);
 
+const IssueService = {
+    getIssues() {
+        const issues = localStorage.getItem('issues');
+
+        return issues ? JSON.paerse(issues) : []
+    },
+    getIssue(id) {
+        return this.getIssues.find(issue => issue.id === id);
+    },
+    saveIssue(issue) {
+        const issues = this.getIssues();
+        issues.push(issue);
+        localStorage.setItem('issues', JSON.stringify(issues));
+    },
+    deleteIssue(id) {
+        const issues = this.getIssues.filter(issue => issue.id !== id);
+
+        localStorage.setItem('issues', JSON.stringify(issues));
+    }
+};
+
 function createIssueTemplate({ id, status, description, severity, assignedTo }) {
     return (
         `<div class="well">
@@ -57,31 +78,37 @@ function saveIssue(e) {
 
   function setStatusClosed (id) {
     const issues = this.issuesList(); 
-    const updateIssue = issues.find(issueToClose => issueToClose.id === id);
+   
+    if (issues.length) {
+        const updateIssue = issues.find(issueToClose => issueToClose.id === id);
 
-    const indOf = issues.indexOf(updateIssue)
-    issues.splice(indOf, 1)
-    issues.push({
-        id : updateIssue.id,
-        description : updateIssue.description,
-        severity : updateIssue.severity,
-        assignedTo : updateIssue.assignedTo,
-        status: 'Closed'
-    })
- 
-    localStorage.setItem('issues', JSON.stringify(issues));
-    
-    fetchIssues();
+        const indOf = issues.indexOf(updateIssue)
+        issues.splice(indOf, 1)
+        issues.push({
+            id: updateIssue.id,
+            description: updateIssue.description,
+            severity: updateIssue.severity,
+            assignedTo: updateIssue.assignedTo,
+            status: 'Closed'
+        })
+
+        localStorage.setItem('issues', JSON.stringify(issues));
+
+        fetchIssues();
+    }
   }
 
   function deleteIssue (id) {
     const issues = this.issuesList();
-    const issueToDelete = issues.find(issueToFind => issueToFind.id === id);
     
-    const indOf = issues.indexOf(issueToDelete)
-    issues.splice(indOf, 1)
-    localStorage.setItem('issues', JSON.stringify(issues));
-    
-    fetchIssues();
+    if (issues.length) {
+        const issueToDelete = issues.find(issueToFind => issueToFind.id === id);
+
+        const indOf = issues.indexOf(issueToDelete)
+        issues.splice(indOf, 1)
+        localStorage.setItem('issues', JSON.stringify(issues));
+
+        fetchIssues();
+    }
   }
   

--- a/main.js
+++ b/main.js
@@ -1,5 +1,19 @@
 document.getElementById('issueInputForm').addEventListener('submit', saveIssue);
 
+function createIssueTemplate({ id, status, description, severity, assignedTo }) {
+    return (
+        `<div class="well">
+            <h6>Issue ID:  ${id} </h6>
+            <p><span class="label label-info">${status}</span></p>
+            <h3>${description}</h3>
+            <p><span class="glyphicon glyphicon-time"></span>${severity}
+            <span class="glyphicon glyphicon-user"></span>${assignedTo}</p>
+            <a href="#" class="btn btn-warning" onclick="setStatusClosed('${id}')">Close</a>
+            <a href="#" class="btn btn-danger" onclick="deleteIssue('${id}')">Delete</a>
+        </div>`
+    );
+}
+
 function issuesList() {
     return localStorage.getItem('issues') ? 
         JSON.parse(localStorage.getItem('issues')) :
@@ -9,24 +23,13 @@ function issuesList() {
 function fetchIssues(){
     const issues = this.issuesList();
     const issuesList = document.getElementById('issuesList');
-
-    issuesList.innerHTML = '';
+    let issueListHtml = '';
 
     if (issues) {
-        issues.forEach(element => {
-            const {id, status, description, severity, assignedTo} = element;
-
-            issuesList.innerHTML +=   `<div class="well">
-            <h6>Issue ID:  ${id} </h6>
-            <p><span class="label label-info">${status}</span></p>
-            <h3>${description}</h3>
-            <p><span class="glyphicon glyphicon-time"></span>${severity}
-            <span class="glyphicon glyphicon-user"></span>${assignedTo}</p>
-            <a href="#" class="btn btn-warning" onclick="setStatusClosed('${id}')">Close</a>
-            <a href="#" class="btn btn-danger" onclick="deleteIssue('${id}')">Delete</a>
-            </div>`;
-        });
+        issues.forEach(element => issueListHtml += createIssueTemplate(element));
     }
+
+    issuesList.innerHTML = issueListHtml;    
 }
 
 function saveIssue(e) {

--- a/main.js
+++ b/main.js
@@ -57,9 +57,7 @@ function saveIssue(e) {
 
   function setStatusClosed (id) {
     const issues = this.issuesList(); 
-    const updateIssue = issues.find(issueToClose => {
-        return issueToClose.id === id
-    })
+    const updateIssue = issues.find(issueToClose => issueToClose.id === id);
 
     const indOf = issues.indexOf(updateIssue)
     issues.splice(indOf, 1)
@@ -78,9 +76,7 @@ function saveIssue(e) {
 
   function deleteIssue (id) {
     const issues = this.issuesList();
-    const issueToDelete = issues.find(issueToFind => {
-        return issueToFind.id === id
-    });
+    const issueToDelete = issues.find(issueToFind => issueToFind.id === id);
     
     const indOf = issues.indexOf(issueToDelete)
     issues.splice(indOf, 1)


### PR DESCRIPTION
### Changes

- Create   ```createIssueTemplate``` to handle templating to avoid multiple assignments of ```innerHTML```

- Refactor ```find``` statements to implicit one liners

### Why was this needed

- Constant assignment to the DOM can affect performance and it's something I didn't think of until later in my dev career. I think it should be something to think about right away even as a beginner reading the blog post.

- Keeping up with the idea of modernizing the original blog post, lets show ES6 implicit returns for function bodies that can be summed up in one line.